### PR TITLE
Check input value on keyup, set date if valid input

### DIFF
--- a/src/litepie-datepicker.vue
+++ b/src/litepie-datepicker.vue
@@ -18,6 +18,7 @@
           v-bind="$attrs"
           v-model="value"
           :placeholder="givenPlaceholder"
+          @keyup="keyUp"
         />
         <span
           class="absolute inset-y-0 right-0 inline-flex items-center rounded-md overflow-hidden"
@@ -669,6 +670,25 @@ export default /*#__PURE__*/ defineComponent({
       }
       applyValue.value = [];
       LitepieInputRef.value && LitepieInputRef.value.focus();
+    };
+
+    const keyUp = () => {
+      if (asRange()) {
+        const [s, e] = value.value.split(props.separator);
+        const [sd, ed] = [
+          dayjs(s, props.formatter.date, true),
+          dayjs(e, props.formatter.date, true)
+        ];
+        if (sd.isValid() && ed.isValid()) {
+          setDate(sd);
+          setDate(ed);
+        }
+      } else {
+        const d = dayjs(value.value, props.formatter.date, true);
+        if (d.isValid()) {
+          setDate(d);
+        }
+      }
     };
 
     const setDate = (date, asNext) => {
@@ -1472,6 +1492,7 @@ export default /*#__PURE__*/ defineComponent({
       asRange,
       show,
       hide,
+      keyUp,
       setDate,
       setHours,
       setMinutes,


### PR DESCRIPTION
When a date is manually entered into the input, compare it against the formatter and set the date if it is valid. This is so the linked model gets updated on manual input as well as through the datepicker.

resolves #6