### PR TITLE
Fix emitShortcut for string model value

### DIFF
--- a/src/litepie-datepicker.vue
+++ b/src/litepie-datepicker.vue
@@ -1282,8 +1282,8 @@ export default /*#__PURE__*/ defineComponent({
               'update:modelValue',
               useToValueFromArray(
                 {
-                  previous: s,
-                  next: e
+                  previous: dayjs(s, props.formatter.date, true),
+                  next: dayjs(e, props.formatter.date, true)
                 },
                 props
               )


### PR DESCRIPTION
When using a model value of string type, the shortcuts don't work.
This PR fixes that problem.