### PR TITLE
Fix single date picker Safari mobile issue

### DIFF
--- a/src/litepie-datepicker.vue
+++ b/src/litepie-datepicker.vue
@@ -89,7 +89,7 @@
                 :i18n="options.shortcuts"
               />
               <!--          Calendar-->
-              <div class="relative flex flex-wrap sm:flex-nowrap p-1">
+              <div class="relative flex flex-wrap sm:flex-nowrap p-1 w-full">
                 <div
                   v-if="asRange() && !asSingle"
                   class="hidden absolute inset-0 sm:flex justify-center items-center"


### PR DESCRIPTION
This PR fixes the single date picker Safari mobile issue

**Steps to reproduce:**
Safari Mac OS - Responsive Mode 
1. Open https://litepie.com/#as-single
2. Enter Responsive mode and choose one of the devices: iPhone SE, iPhone 8, iPhone 8 Plus
3. Open the date picker by clicking on the input

Safari iOS
1. Open https://litepie.com/#as-single
2. Open the date picker by clicking on the input for the first time 
3. Close the date picker by clicking on the cancel button
4. Open the date picker by clicking on the input for the second time

**Before:**
<img width="376" alt="CleanShot 2022-08-02 at 17 58 24@2x" src="https://user-images.githubusercontent.com/38343686/182406315-1b455c7e-0c34-49f1-b3ad-d4ea977243cc.png">

**After:**
<img width="376" alt="CleanShot 2022-08-02 at 17 57 03@2x" src="https://user-images.githubusercontent.com/38343686/182406353-1c69907e-c2ca-49bc-9039-85197501a9e4.png">

